### PR TITLE
feat: define road & add lanes to the road ctx canvas 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "commitlint",
+        "lerp",
         "mononom",
         "nnwml",
         "stylelint"

--- a/apps/nnwml/self-driving-car/src/app/features/road.ts
+++ b/apps/nnwml/self-driving-car/src/app/features/road.ts
@@ -23,26 +23,21 @@ export class Road {
   draw(ctx: CanvasRenderingContext2D): void {
     ctx.lineWidth = 5 as number;
     ctx.strokeStyle = 'white' as string | CanvasGradient | CanvasPattern;
-    // add multiple lanes with a for loop
+
     for (let i = 0; i < this.laneCount; i += 1) {
-      // we need to find the x coordinate of the lane lines to draw
-      /* use LINEAR INTERPOLATION or lerp
-      getting values from left to right depending on a percentage
-      i.e. is i/laneCount */
-      const x = lerp(this.left, this.right, i / this.laneCount);
-    }
-    // draw line on left side of road
-    ctx.beginPath();
-    ctx.moveTo(this.left, this.top);
-    ctx.lineTo(this.left, this.bottom);
-    ctx.stroke();
-    // draw line on right side of road
-    ctx.beginPath();
-    ctx.moveTo(this.right, this.top);
-    ctx.lineTo(this.right, this.bottom);
-    ctx.stroke();
-  } /* after this add in main.ts
-  const road = new Road(canvas.width/2, canvas.width) */
+      /**
+       * LINEAR INTERPOLATION or lerp getting values from left to right depending on a percentage i.e. is i/laneCount => * we need to find the x coordinate of the lane lines to draw
+       * @date 5/19/2022 - 12:47:11 PM
+       *
+       * @type {number}
+       */
+      const x: number = lerp(this.left, this.right, i / this.laneCount);
+      ctx.beginPath();
+      ctx.moveTo(x, this.top);
+      ctx.lineTo(x, this.bottom);
+      ctx.stroke(); /* after this add in main.ts => const road = new Road(canvas.width/2, canvas.width) */
+    } // add multiple lanes with a for loop
+  }
 }
 
 /**

--- a/apps/nnwml/self-driving-car/src/app/features/road.ts
+++ b/apps/nnwml/self-driving-car/src/app/features/road.ts
@@ -1,11 +1,11 @@
 export class Road {
-  x: number;
-  width: number;
+  bottom: number;
   laneCount: number;
   left: number;
   right: number;
   top: number;
-  bottom: number;
+  width: number;
+  x: number;
   constructor(x: number, width: number, laneCount = 3 as number) {
     this.x = x;
     this.width = width;
@@ -23,6 +23,14 @@ export class Road {
   draw(ctx: CanvasRenderingContext2D): void {
     ctx.lineWidth = 5 as number;
     ctx.strokeStyle = 'white' as string | CanvasGradient | CanvasPattern;
+    // add multiple lanes with a for loop
+    for (let i = 0; i < this.laneCount; i += 1) {
+      // we need to find the x coordinate of the lane lines to draw
+      /* use LINEAR INTERPOLATION or lerp
+      getting values from left to right depending on a percentage
+      i.e. is i/laneCount */
+      const x = lerp(this.left, this.right, i / this.laneCount);
+    }
     // draw line on left side of road
     ctx.beginPath();
     ctx.moveTo(this.left, this.top);
@@ -35,4 +43,20 @@ export class Road {
     ctx.stroke();
   } /* after this add in main.ts
   const road = new Road(canvas.width/2, canvas.width) */
+}
+
+/**
+ * Linear Interpolation between two values A and B based on the percentage t
+ * when t = 0, return A
+ * when t = 1, return B
+ * when t = 0.5, return the midpoint between A and B
+ * @date 5/19/2022 - 12:40:55 PM
+ *
+ * @param {number} A
+ * @param {number} B
+ * @param {number} t
+ * @returns {number}
+ */
+export function lerp(A: number, B: number, t: number): number {
+  return (A + (B - A) * t) as number;
 }

--- a/apps/nnwml/self-driving-car/src/app/features/road.ts
+++ b/apps/nnwml/self-driving-car/src/app/features/road.ts
@@ -1,3 +1,5 @@
+import { lerp } from '../utils/lerp';
+
 export class Road {
   bottom: number;
   laneCount: number;
@@ -37,20 +39,4 @@ export class Road {
       ctx.stroke(); /* after this add in main.ts => const road = new Road(canvas.width/2, canvas.width) */
     } // add multiple lanes with a for loop
   }
-}
-
-/**
- * Linear Interpolation between two values A and B based on the percentage t
- * when t = 0, return A
- * when t = 1, return B
- * when t = 0.5, return the midpoint between A and B
- * @date 5/19/2022 - 12:40:55 PM
- *
- * @param {number} A
- * @param {number} B
- * @param {number} t
- * @returns {number}
- */
-export function lerp(A: number, B: number, t: number): number {
-  return (A + (B - A) * t) as number;
 }

--- a/apps/nnwml/self-driving-car/src/app/features/road.ts
+++ b/apps/nnwml/self-driving-car/src/app/features/road.ts
@@ -14,8 +14,7 @@ export class Road {
     this.left = (x as number) - (width as number) / 2;
     this.right = (x as number) + (width as number) / 2;
 
-    // want the road to go infinitely downwards
-    const infinity = 1000000; // using JS infinity may cause problems when drawing
+    const infinity = 1000000; // using JS infinity may cause problems when drawing // want the road to go infinitely downwards
     this.top = -infinity as number;
     this.bottom = infinity as number;
   }
@@ -24,14 +23,14 @@ export class Road {
     ctx.lineWidth = 5 as number;
     ctx.strokeStyle = 'white' as string | CanvasGradient | CanvasPattern;
 
-    for (let i = 0; i < this.laneCount; i += 1) {
-      /**
-       * LINEAR INTERPOLATION or lerp getting values from left to right depending on a percentage i.e. is i/laneCount => * we need to find the x coordinate of the lane lines to draw
-       * @date 5/19/2022 - 12:47:11 PM
-       *
-       * @type {number}
-       */
-      const x: number = lerp(this.left, this.right, i / this.laneCount);
+    for (let i = 0; i < ((this.laneCount + 1) as number); i += 1) {
+      /** LINEAR INTERPOLATION or lerp getting values from left to right depending on a percentage i.e. is i/laneCount => * we need to find the x coordinate of the lane lines to draw */
+      const x: number = lerp(
+        this.left,
+        this.right,
+        (i / this.laneCount) as number
+      );
+
       ctx.beginPath();
       ctx.moveTo(x, this.top);
       ctx.lineTo(x, this.bottom);

--- a/apps/nnwml/self-driving-car/src/app/utils/lerp.spec.ts
+++ b/apps/nnwml/self-driving-car/src/app/utils/lerp.spec.ts
@@ -1,0 +1,39 @@
+import { lerp } from './lerp';
+
+describe('lerp', () => {
+  it('should return the midpoint between two numbers', () => {
+    expect(lerp(0, 1, 0.5)).toEqual(0.5);
+  });
+
+  it('should return the first number when t is 0', () => {
+    expect(lerp(0, 1, 0)).toEqual(0);
+  });
+
+  it('should return the second number when t is 1', () => {
+    expect(lerp(0, 1, 1)).toEqual(1);
+  });
+
+  it('should return the midpoint between two numbers 30 & 45 => 37.5', () => {
+    expect(lerp(30, 45, 0.5)).toEqual(37.5);
+  });
+});
+
+describe('lerp', () => {
+  it('should return negative values when t is negative', () => {
+    expect(lerp(-1, 1, -0.5)).toEqual(-2);
+  });
+
+  it('should return positive values when t is positive', () => {
+    expect(lerp(-1, 1, 0.5)).toEqual(0);
+    expect(lerp(-1, 1, 0.5)).not.toEqual(-0.5);
+  });
+
+  it('should not throw an error if there are no arguments with another method', () => {
+    const mockLerp = () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.5);
+      return lerp(0, 1, 0.5);
+    };
+
+    expect(() => mockLerp()).not.toThrow();
+  });
+});

--- a/apps/nnwml/self-driving-car/src/app/utils/lerp.ts
+++ b/apps/nnwml/self-driving-car/src/app/utils/lerp.ts
@@ -14,5 +14,3 @@
 export function lerp(A: number, B: number, t: number): number {
   return (A + (B - A) * t) as number;
 }
-
-console.log(lerp(-1, 1, -0.5));

--- a/apps/nnwml/self-driving-car/src/app/utils/lerp.ts
+++ b/apps/nnwml/self-driving-car/src/app/utils/lerp.ts
@@ -1,0 +1,18 @@
+/**
+ * Linear Interpolation between two values A and B based on the percentage t
+ * when t = 0, return A
+ * when t = 1, return B
+ * when t = 0.5, return the midpoint between A and B
+ * @date 5/19/2022 - 1:00:32 PM
+ *
+ * @export
+ * @param {number} A
+ * @param {number} B
+ * @param {number} t
+ * @returns {number}
+ */
+export function lerp(A: number, B: number, t: number): number {
+  return (A + (B - A) * t) as number;
+}
+
+console.log(lerp(-1, 1, -0.5));


### PR DESCRIPTION
## What changed

- The road now has border lines offset by a small margin.
  - This was enabled by multiplying road width by 0.9 `canvas.width * 0.9`.
- Add multiple lanes using `for` loops. Can implement `forEach` method.
- Add a linear interpolation function or `lerp()`.
  - `function lerp(A: number, B: number, t: number): number => (A + (B - A) * t) as number;`
  - Linear Interpolation between two values A and B based on the percentage t
    - when t = 0, return A
    - when t = 1, return B
    - when t = 0.5, return the midpoint between A and B

## Commits

- da2162e chore: refactor lerp() into utils folder
- 776e5b5 fix: add + 1 to for loop boolean laneCount
- 5754952 refactor: modify lane path this.left/right to x
- f90560f feat: add linearInterpolation lerp() utility

