### PR TITLE
feat: build road borders

### DIFF
--- a/apps/nnwml/nascar/src/app/features/road.ts
+++ b/apps/nnwml/nascar/src/app/features/road.ts
@@ -3,16 +3,12 @@ import { lerp } from '../utils/';
 export class Road {
   left: number;
   right: number;
-  top: number;
-  bottom: number;
+  borders: { x: number; y: number; radius: number }[];
   constructor(public x: number, public width: number, public laneCount = 6) {
     this.x = x;
     this.width = width;
     this.laneCount = laneCount;
 
-    const infinity = 1000000;
-    this.top = -infinity;
-    this.bottom = infinity;
     // this.lanes = [];
     // for (let i = 0; i < this.laneCount; i++) {
     //   this.lanes.push(new Lane(this.x, this.y, this.width, i));
@@ -20,6 +16,15 @@ export class Road {
 
     this.left = x - width / 2;
     this.right = x + width / 2;
+
+    // draw border for circular lanes where the car can go in circle, this.borders is an array of objects
+    this.borders = [
+      {
+        x: this.left,
+        y: this.right,
+        radius: (this.right - this.left) / 2,
+      },
+    ];
   }
 
   /**
@@ -43,10 +48,9 @@ export class Road {
   draw(ctx) {
     ctx.lineWidth = 4;
     ctx.strokeStyle = '#fff';
-
-    for (let i = 0; i <= this.laneCount; i += 1) {
-      // what is the x coordinate of each of the lines/arcs? Use linear interpolation
+    for (let i = 1; i <= this.laneCount - 1; i += 1) {
       const x = lerp(this.left, this.right, i / this.laneCount);
+      // what is the x coordinate of each of the lines/arcs? Use linear interpolation
       // const y = lerp(this.right, this.left, i / this.laneCount);
       if (i > 3 && i < this.laneCount) {
         ctx.setLineDash([20, 20]);
@@ -55,17 +59,52 @@ export class Road {
       }
 
       ctx.beginPath();
-      ctx.lineWidth = 0;
       ctx.arc(this.width / 2, this.right / 2, x / 2, 0, Math.PI * 2);
+      ctx.stroke();
+      this.borders.push({
+        x: this.width,
+        y: this.right,
+        radius: x / 2,
+      });
+    }
 
+    ctx.beginPath();
+    for (let i = 0; i < this.laneCount; i++) {
+      this.borders[i].x = this.getLaneCenter(i);
+      this.borders[i].y = this.right;
+      ctx.strokeStyle = 'red';
+      ctx.arc(
+        this.borders[i].x,
+        this.borders[i].y,
+        this.borders[i].radius,
+        0,
+        Math.PI * 2
+      );
       ctx.stroke();
     }
+    // instead do it for borders[0] and borders[laneCount] -> forEach won't work but it can if it's for sensors!!!
+    // ctx.setLineDash([]);
+    // ctx.lineWidth = 4;
+    // ctx.strokeStyle = 'red';
+    // this.borders.forEach((border) => {
+    //   ctx.beginPath();
+    //   ctx.arc(this.width / 2, this.right / 2, border.radius, 0, Math.PI * 2);
+    //   ctx.stroke();
+    // });
   }
 }
 
 /**
  * ARCHIVE
  *
+ * @202205251845
+ *  ctx.lineWidth = 4;
+    ctx.strokeStyle = 'red';
+    this.borders.forEach((border) => {
+      ctx.beginPath();
+      ctx.arc(this.width / 2, this.right / 2, border.radius, 0, Math.PI * 2);
+      ctx.stroke();
+    });
  * @202205251541
  * ctx.arc(
   (this.left + this.right) / 2,

--- a/apps/nnwml/nascar/src/app/features/road.ts
+++ b/apps/nnwml/nascar/src/app/features/road.ts
@@ -51,7 +51,6 @@ export class Road {
     for (let i = 1; i <= this.laneCount - 1; i += 1) {
       const x = lerp(this.left, this.right, i / this.laneCount);
       // what is the x coordinate of each of the lines/arcs? Use linear interpolation
-      // const y = lerp(this.right, this.left, i / this.laneCount);
       if (i > 3 && i < this.laneCount) {
         ctx.setLineDash([20, 20]);
       } else {
@@ -68,11 +67,11 @@ export class Road {
       });
     }
 
-    ctx.beginPath();
     for (let i = 0; i < this.laneCount; i++) {
-      this.borders[i].x = this.getLaneCenter(i);
-      this.borders[i].y = this.right;
-      ctx.strokeStyle = 'red';
+      ctx.beginPath();
+      this.borders[i].x = this.width / 2;
+      this.borders[i].y = this.right / 2;
+      ctx.strokeStyle = '#ff00ff20';
       ctx.arc(
         this.borders[i].x,
         this.borders[i].y,
@@ -82,15 +81,6 @@ export class Road {
       );
       ctx.stroke();
     }
-    // instead do it for borders[0] and borders[laneCount] -> forEach won't work but it can if it's for sensors!!!
-    // ctx.setLineDash([]);
-    // ctx.lineWidth = 4;
-    // ctx.strokeStyle = 'red';
-    // this.borders.forEach((border) => {
-    //   ctx.beginPath();
-    //   ctx.arc(this.width / 2, this.right / 2, border.radius, 0, Math.PI * 2);
-    //   ctx.stroke();
-    // });
   }
 }
 
@@ -105,6 +95,15 @@ export class Road {
       ctx.arc(this.width / 2, this.right / 2, border.radius, 0, Math.PI * 2);
       ctx.stroke();
     });
+    // instead do it for borders[0] and borders[laneCount] -> forEach won't work but it can if it's for sensors!!!
+    // ctx.setLineDash([]);
+    // ctx.lineWidth = 4;
+    // ctx.strokeStyle = 'red';
+    // this.borders.forEach((border) => {
+    //   ctx.beginPath();
+    //   ctx.arc(this.width / 2, this.right / 2, border.radius, 0, Math.PI * 2);
+    //   ctx.stroke();
+    // });
  * @202205251541
  * ctx.arc(
   (this.left + this.right) / 2,

--- a/apps/nnwml/nascar/src/main.ts
+++ b/apps/nnwml/nascar/src/main.ts
@@ -23,9 +23,14 @@ function animate() {
 
   canvas.height = 700;
   // canvas.height = (window.innerHeight * 70) / 100;
+
+  ctx.save();
+  ctx.translate(0, -car.y + canvas.height * 0.5);
+  // ctx.scale(1.4, 1.4);
   road.draw(ctx);
 
   car.draw(ctx);
+  ctx.restore();
   // traffic.forEach((car) => {
   //   car.draw(ctx);
   // });

--- a/apps/nnwml/nascar/src/main.ts
+++ b/apps/nnwml/nascar/src/main.ts
@@ -25,7 +25,7 @@ function animate() {
   // canvas.height = (window.innerHeight * 70) / 100;
 
   ctx.save();
-  ctx.translate(0, -car.y + canvas.height * 0.5);
+  ctx.translate(-car.x + canvas.width / 2, -car.y + canvas.height / 2);
   // ctx.scale(1.4, 1.4);
   road.draw(ctx);
 


### PR DESCRIPTION
## Why 

- Adds borders for sensors to detect the lane edges.

## Changes

- [fix: add border functionality slow perf](https://github.com/lloydlobo/mononom-web-apps/commit/047485c8f4b51ae36569fcb74d095e0d2aa19731)
- [fix: position the borders on the lane](https://github.com/lloydlobo/mononom-web-apps/commit/c0af4cc7b1dc82c28d1060e4f15eb62d35979d14)
- [feat: add cool camera trick on context](https://github.com/lloydlobo/mononom-web-apps/commit/9c3770bd7ebae725109fa897fcbdd0a91462e131)
- [perf: add x coordinate for camera translate car](https://github.com/lloydlobo/mononom-web-apps/commit/a8eccea136560abc7e6cdaf4f94271a6d933aca5)

## Can be improved

- UI - line dashes only for lanes and not for the exterior border.
- A if statement may do the trick